### PR TITLE
Bump org.junit.vintage:junit-vintage-engine from 5.14.1 to 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-jcl:2.25.2'
 
   testImplementation 'junit:junit:4.13.2'
-  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.14.1'
+  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:6.0.1'
   testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
   codenarc('org.codenarc:CodeNarc:3.7.0-groovy-4.0')


### PR DESCRIPTION
Fixes #66